### PR TITLE
Alpha9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs-plugin-api",
-  "version": "0.0.1-alpha.8",
+  "version": "0.0.1-alpha.9",
   "description": "An (experimental) API for writing plugins for terriajs.",
   "repository": "https://github.com/terriajs/plugin-api",
   "license": "Apache-2.0",

--- a/src/Models.ts
+++ b/src/Models.ts
@@ -40,7 +40,6 @@ import {
   default as SelectableDimensionWorkflow,
   runWorkflow
 } from "terriajs/lib/Models/Workflows/SelectableDimensionWorkflow";
-export { UrlToCatalogMemberMapping } from "terriajs/lib/Models/Catalog/CatalogReferences/UrlReference";
 
 
 import * as MapToolbar from "terriajs/lib/ViewModels/MapNavigation/MapToolbar";


### PR DESCRIPTION
Remove direct export of - UrlToCatalogMemberMapping
Instead use `UploadDataTypes.registerUrlHandlerForCatalogMemberType()`