### PR TITLE
Fix import and bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs-plugin-api",
-  "version": "0.0.1-alpha.16",
+  "version": "0.0.1-alpha.17",
   "description": "An (experimental) API for writing plugins for terriajs.",
   "repository": "https://github.com/terriajs/plugin-api",
   "license": "Apache-2.0",

--- a/src/Deprecated.ts
+++ b/src/Deprecated.ts
@@ -1,3 +1,3 @@
 export { default as ModalPopup } from "terriajs/lib/ReactViews/ExplorerWindow/ModalPopup";
 export { default as Tabs } from "terriajs/lib/ReactViews/ExplorerWindow/Tabs";
-export const MyDataTab = require("terriajs/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/MyDataTab");
+export { default as MyDataTab } from "terriajs/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/MyDataTab";

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,2 +1,3 @@
 declare module "terriajs/lib/ReactViews/ExplorerWindow/Tabs";
 declare module "terriajs/lib/ReactViews/Preview/DataPreviewMap";
+declare module "terriajs/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/MyDataTab";


### PR DESCRIPTION
- Replaces CJS style `require()` with `import` for terriajs `8.8.x`
- Bump version to `0.0.1-alpha.17`